### PR TITLE
Implement Cw4626ExecuteMsg and simplify API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ default = []
 lockup = ["cw-utils"]
 keeper = []
 cw20 = ["dep:cw20", "dep:cw-asset"]
+cw4626 = ["cw20"]
 
 [dependencies]
 cosmwasm-std = "1.1.0"

--- a/src/cw4626.rs
+++ b/src/cw4626.rs
@@ -1,0 +1,82 @@
+use cosmwasm_std::{Binary, Empty, Uint128};
+use cw20::{Cw20Coin, Expiration, Logo};
+
+use crate::msg::ExtensionExecuteMsg;
+
+pub enum Cw4626ExecuteMsg<T = ExtensionExecuteMsg, S = Empty> {
+    //--------------------------------------------------------------------------------------------------
+    // Standard CW20 ExecuteMsgs
+    //--------------------------------------------------------------------------------------------------
+    /// Transfer is a base message to move tokens to another account without triggering actions
+    Transfer {
+        recipient: String,
+        amount: Uint128,
+    },
+    /// Send is a base message to transfer tokens to a contract and trigger an action
+    /// on the receiving contract.
+    Send {
+        contract: String,
+        amount: Uint128,
+        msg: Binary,
+    },
+    /// Only with "approval" extension. Allows spender to access an additional amount tokens
+    /// from the owner's (env.sender) account. If expires is Some(), overwrites current allowance
+    /// expiration with this one.
+    IncreaseAllowance {
+        spender: String,
+        amount: Uint128,
+        expires: Option<Expiration>,
+    },
+    /// Only with "approval" extension. Lowers the spender's access of tokens
+    /// from the owner's (env.sender) account by amount. If expires is Some(), overwrites current
+    /// allowance expiration with this one.
+    DecreaseAllowance {
+        spender: String,
+        amount: Uint128,
+        expires: Option<Expiration>,
+    },
+    /// Only with "approval" extension. Transfers amount tokens from owner -> recipient
+    /// if `env.sender` has sufficient pre-approval.
+    TransferFrom {
+        owner: String,
+        recipient: String,
+        amount: Uint128,
+    },
+    /// Only with "approval" extension. Sends amount tokens from owner -> contract
+    /// if `env.sender` has sufficient pre-approval.
+    SendFrom {
+        owner: String,
+        contract: String,
+        amount: Uint128,
+        msg: Binary,
+    },
+    /// Only with the "marketing" extension. If authorized, updates marketing metadata.
+    /// Setting None/null for any of these will leave it unchanged.
+    /// Setting Some("") will clear this field on the contract storage
+    UpdateMarketing {
+        /// A URL pointing to the project behind this token.
+        project: Option<String>,
+        /// A longer description of the token and it's utility. Designed for tooltips or such
+        description: Option<String>,
+        /// The address (if any) who can update this data structure
+        marketing: Option<String>,
+    },
+    /// If set as the "marketing" role on the contract, upload a new URL, SVG, or PNG for the token
+    UploadLogo(Logo),
+    //--------------------------------------------------------------------------------------------------
+    // CW4626 ExecuteMsgs
+    //--------------------------------------------------------------------------------------------------
+    Deposit {
+        cw20s: Option<Vec<Cw20Coin>>,
+        recipient: Option<String>,
+    },
+
+    Redeem {
+        recipient: Option<String>,
+        amount: Uint128,
+    },
+
+    Callback(S),
+
+    VaultExtension(T),
+}

--- a/src/cw4626.rs
+++ b/src/cw4626.rs
@@ -1,8 +1,10 @@
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Binary, Empty, Uint128};
 use cw20::{Cw20Coin, Expiration, Logo};
 
 use crate::msg::ExtensionExecuteMsg;
 
+#[cw_serde]
 pub enum Cw4626ExecuteMsg<T = ExtensionExecuteMsg, S = Empty> {
     //--------------------------------------------------------------------------------------------------
     // Standard CW20 ExecuteMsgs

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -11,15 +11,7 @@ pub enum LockupExecuteMsg {
     WithdrawUnlocked {
         /// An optional field containing which address should receive the
         /// withdrawn underlying assets.
-        receiver: Option<String>,
-        // An optional field containing a binary encoded CosmosMsg. If set, the
-        // vault will return the underlying assets to receiver and assume that
-        // receiver is a contract and try to execute the binary encoded
-        // ExecuteMsg on the contract.
-        //
-        // TODO: Keep this? Figure out best Receiver API.
-        // contract_msg: Option<Binary>,
-        //
+        recipient: Option<String>,
         /// The ID of the expired lockup to withdraw from.
         /// If None is passed, the vault will attempt to withdraw all expired
         /// lockup positions. Note that this can fail if there are too many

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -2,6 +2,9 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin, Uint128};
 use cw_utils::{Duration, Expiration};
 
+#[cfg(feature = "cw20")]
+use cw20::Cw20Coin;
+
 #[cw_serde]
 pub enum LockupExecuteMsg {
     /// Withdraw an unlocking position that has finished unlocking.

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -25,7 +25,10 @@ pub enum LockupExecuteMsg {
     /// Emits an Unlock event with `amount` attribute containing an u64 lockup_id.
     /// Also encodes the u64 lockup ID as binary and returns it in the Response's
     /// data field, so that it can be read by SubMsg replies.
-    Unlock,
+    ///
+    /// Like Redeem, this takes an amount so that the same API can be used for
+    /// CW4626 and native tokens.
+    Unlock { amount: Uint128 },
 
     /// Can be called by whitelisted addresses to bypass the lockup and
     /// immediately return the underlying assets. Used in the event of

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -7,6 +7,17 @@ use cw20::Cw20Coin;
 
 #[cw_serde]
 pub enum LockupExecuteMsg {
+    /// Unlock is called to initiate unlocking a locked position held by the
+    /// vault.
+    /// The caller must pass the native vault tokens in the funds field.
+    /// Emits an Unlock event with `amount` attribute containing an u64 lockup_id.
+    /// Also encodes the u64 lockup ID as binary and returns it in the Response's
+    /// data field, so that it can be read by SubMsg replies.
+    ///
+    /// Like Redeem, this takes an amount so that the same API can be used for
+    /// CW4626 and native tokens.
+    Unlock { amount: Uint128 },
+
     /// Withdraw an unlocking position that has finished unlocking.
     WithdrawUnlocked {
         /// An optional field containing which address should receive the
@@ -19,17 +30,6 @@ pub enum LockupExecuteMsg {
         lockup_id: Option<u64>,
     },
 
-    /// Unlock is called to initiate unlocking a locked position held by the
-    /// vault.
-    /// The caller must pass the native vault tokens in the funds field.
-    /// Emits an Unlock event with `amount` attribute containing an u64 lockup_id.
-    /// Also encodes the u64 lockup ID as binary and returns it in the Response's
-    /// data field, so that it can be read by SubMsg replies.
-    ///
-    /// Like Redeem, this takes an amount so that the same API can be used for
-    /// CW4626 and native tokens.
-    Unlock { amount: Uint128 },
-
     /// Can be called by whitelisted addresses to bypass the lockup and
     /// immediately return the underlying assets. Used in the event of
     /// liquidation. The caller must pass the native vault tokens in the funds
@@ -37,6 +37,8 @@ pub enum LockupExecuteMsg {
     ForceWithdraw {
         /// The address which should receive the withdrawn assets.
         recipient: Option<String>,
+        /// The amount of vault tokens to force unlock.
+        amount: Uint128,
     },
 
     /// Force withdraw from a position that is already unlocking (Unlock has

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,5 @@
 pub mod extensions;
 pub mod msg;
+
+#[cfg(feature = "cw4626")]
+pub mod cw4626;

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -13,7 +13,7 @@ use crate::extensions::lockup::{LockupExecuteMsg, LockupQueryMsg};
 use crate::extensions::keeper::{KeeperExecuteMsg, KeeperQueryMsg};
 
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Binary, Decimal, Uint128};
+use cosmwasm_std::Uint128;
 use cosmwasm_std::{Coin, Empty};
 use schemars::JsonSchema;
 
@@ -27,9 +27,9 @@ pub enum ExecuteMsg<T = ExtensionExecuteMsg, S = Empty> {
         /// pre-approved.
         #[cfg(feature = "cw20")]
         cw20s: Option<Vec<Cw20Coin>>,
-        /// The optional receiver of the vault token. If not set, the caller
+        /// The optional recipient of the vault token. If not set, the caller
         /// address will be used instead.
-        receiver: Option<String>,
+        recipient: Option<String>,
     },
 
     /// Called to redeem vault tokens and receive assets back from the vault.
@@ -39,7 +39,7 @@ pub enum ExecuteMsg<T = ExtensionExecuteMsg, S = Empty> {
     Redeem {
         /// An optional field containing which address should receive the
         /// withdrawn underlying assets.
-        receiver: Option<String>,
+        recipient: Option<String>,
         /// The amount of vault tokens sent to the contract. In the case that
         /// the vault token is a Cosmos native denom, we of course have this
         /// information in the info.funds, but if the vault implements the Cw4626
@@ -113,18 +113,18 @@ where
     PreviewRedeem { shares: Uint128 },
 
     /// Returns `Option<AssetsResponse>` maximum amount of assets that can be
-    /// deposited into the Vault for the `receiver`, through a call to Deposit.
+    /// deposited into the Vault for the `recipient`, through a call to Deposit.
     ///
     /// MUST return the maximum amount of assets deposit would allow to be
-    /// deposited for `receiver` and not cause a revert, which MUST NOT be higher
+    /// deposited for `recipient` and not cause a revert, which MUST NOT be higher
     /// than the actual maximum that would be accepted (it should underestimate
     /// if necessary). This assumes that the user has infinite assets, i.e.
-    /// MUST NOT rely on the asset balances of `receiver`.
+    /// MUST NOT rely on the asset balances of `recipient`.
     ///
     /// MUST factor in both global and user-specific limits, like if deposits
     /// are entirely disabled (even temporarily) it MUST return 0.
     #[returns(Option<AssetsResponse>)]
-    MaxDeposit { receiver: String },
+    MaxDeposit { recipient: String },
 
     /// Returns `Option<Uint128>` maximum amount of Vault shares that can be redeemed
     /// from the owner balance in the Vault, through a call to Withdraw
@@ -252,28 +252,4 @@ pub struct VaultInfo {
     pub deposit_cw20s: Vec<Cw20Coin>,
     /// Denom of vault token
     pub vault_token_denom: String,
-}
-
-pub struct VaultReceiveMsg {
-    pub sender: String,
-    pub amount: Uint128,
-    pub msg: Binary,
-}
-
-/// Zapper that does not need to know Vault API
-pub enum GeneralizedZapperExecuteMsg {
-    Zap {
-        /// If cw20 assets are sent, they must be listed here and have pre-approved
-        /// allowance set.
-        assets: Option<Vec<Coin>>,
-        /// The asset the caller wishes to receive
-        receive_asset: String,
-        /// The recipient of the converted assets
-        recipient: String,
-        /// If set will try to call the binary encoded ExecuteMsg on recipient
-        contract_msg: Option<Binary>,
-        /// The slippage tolerance to use when converting. The zapper will use
-        /// some internal oracle to value the input and output assets.
-        slippage_tolerance: Option<Decimal>,
-    },
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -208,6 +208,7 @@ pub struct AssetsResponse {
     pub cw20s: Vec<Cw20Coin>,
 }
 
+#[cfg(not(feature = "cw20"))]
 impl From<Vec<Coin>> for AssetsResponse {
     fn from(coins: Vec<Coin>) -> Self {
         Self { coins }


### PR DESCRIPTION
Implements a separate Cw4626ExecuteMsg that combines the variants from the vault standard ExecuteMsg and Cw20 ExecuteMsg. In order to keep the same API between the regular vault standard and Cw4626 ExecuteMsgs I renamed Withdraw to Redeem since this actually describes more accurately what the function does (redeems a specific amount of vault tokens, rather than withdrawing a certain amount of assets).

To simplify I also removed `PreviewMint` `PreviewWithdraw`, `MaxMint`, and `MaxWithdraw` QueryMsgs. If we ever feel we need them we can still add them back without braking changes since Withdraw is now called Redeem.