### PR TITLE
[WIP] Address Gabe's feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,8 +63,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-utils 0.15.0",
- "cw20 0.15.0",
+ "cw-utils 0.16.0",
+ "cw20 0.16.0",
  "schemars",
  "serde",
 ]
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ba3fb5fad2dce94263d070848b2befc46b5c8e4929adfb9a3595267823d6ec"
+checksum = "d9b6f91c0b94481a3e9ef1ceb183c37d00764f8751e39b45fc09f4d9b970d469"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a67007ff056f4cd034f361c8ed69780c0180959b9c8037c84f3caa78120faf5"
+checksum = "d6a84c6c1c0acc3616398eba50783934bd6c964bad6974241eaee3460c8f5b26"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -261,13 +261,13 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a1924a28607bf7cb9fd6681a64feea3e5fa9a8cb71fb4d24cf33635b21065a"
+checksum = "91398113b806f4d2a8d5f8d05684704a20ffd5968bf87e3473e1973710b884ad"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.15.0",
+ "cw-storage-plus 0.16.0",
  "schemars",
  "serde",
 ]
@@ -286,13 +286,13 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a48e4a85c0a31484e053a3eea15abfc3ed24fafc1a1a3e91181a0bd3a8ee91"
+checksum = "a45a8794a5dd33b66af34caee52a7beceb690856adcc1682b6e3db88b2cdee62"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 0.15.0",
+ "cw-utils 0.16.0",
  "schemars",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ cosmwasm-std = "1.1.0"
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 cosmwasm-schema = { version = "1.1.0" }
-cw-utils = { version = "0.15.0", optional = true }
-cw20 = { version = "0.15.0", optional = true }
+cw-utils = { version = "0.16.0", optional = true }
+cw20 = { version = "0.16.0", optional = true }
 cw-asset = { version = "2.3.0", optional = true }

--- a/src/cw4626.rs
+++ b/src/cw4626.rs
@@ -70,10 +70,14 @@ pub enum Cw4626ExecuteMsg<T = ExtensionExecuteMsg, S = Empty> {
     //--------------------------------------------------------------------------------------------------
     Deposit {
         cw20s: Option<Vec<Cw20Coin>>,
+        /// An optional field containing the recipient of the vault token. If not set, the
+        /// caller address will be used instead.
         recipient: Option<String>,
     },
 
     Redeem {
+        /// An optional field containing which address should receive the withdrawn underlying assets.
+        /// If not set, the caller address will be used instead.
         recipient: Option<String>,
         amount: Uint128,
     },

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -16,8 +16,9 @@ pub enum LockupExecuteMsg {
     /// Unlock is called to initiate unlocking a locked position held by the
     /// vault.
     /// The caller must pass the native vault tokens in the funds field.
-    /// Emits an event with type `UNLOCK_EVENT_TYPE` with an attribute with key
-    /// `UNLOCKING_POSITION_ATTR_KEY` containing an u64 lockup_id.
+    /// Emits an event with type `UNLOCKING_POSITION_CREATED_EVENT_TYPE` with
+    /// an attribute with key `UNLOCKING_POSITION_ATTR_KEY` containing an u64
+    /// lockup_id.
     /// Also encodes the u64 lockup ID as binary and returns it in the Response's
     /// data field, so that it can be read by SubMsg replies.
     ///

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -28,7 +28,8 @@ pub enum LockupExecuteMsg {
     /// Withdraw an unlocking position that has finished unlocking.
     WithdrawUnlocked {
         /// An optional field containing which address should receive the
-        /// withdrawn underlying assets.
+        /// withdrawn underlying assets. If not set, the caller address will be
+        /// used instead.
         recipient: Option<String>,
         /// The ID of the expired lockup to withdraw from.
         /// If None is passed, the vault will attempt to withdraw all expired
@@ -42,7 +43,8 @@ pub enum LockupExecuteMsg {
     /// liquidation. The caller must pass the native vault tokens in the funds
     /// field.
     ForceWithdraw {
-        /// The address which should receive the withdrawn assets.
+        /// The address which should receive the withdrawn assets. If not set,
+        /// the caller address will be used instead.
         recipient: Option<String>,
         /// The amount of vault tokens to force unlock.
         amount: Uint128,

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -27,7 +27,7 @@ pub enum LockupExecuteMsg {
         /// If None is passed, the vault will attempt to withdraw all expired
         /// lockup positions. Note that this can fail if there are too many
         /// lockup positions and the `max_contract_gas` limit is hit.
-        lockup_id: Option<u64>,
+        lockup_id: u64,
     },
 
     /// Can be called by whitelisted addresses to bypass the lockup and

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -59,7 +59,7 @@ pub enum LockupExecuteMsg {
         /// If None is passed, the entire position will be force withdrawn.
         /// Vaults MAY require the ratio of assets to be the same as the ratio
         /// in the `deposit_assets` field returned by the `VaultInfo` query.
-        amounts: Option<Vec<Coin>>,
+        amount: Option<Uint128>,
         #[cfg(feature = "cw20")]
         cw20s_amounts: Option<Vec<Cw20Coin>>,
         /// The address which should receive the withdrawn assets. If not set,

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -53,13 +53,9 @@ pub enum LockupExecuteMsg {
     ForceWithdrawUnlocking {
         /// The ID of the unlocking position from which to force withdraw
         lockup_id: u64,
-        /// Optional amounts of each underlying asset to be force withdrawn.
+        /// Optional amount of the underlying asset to be force withdrawn.
         /// If None is passed, the entire position will be force withdrawn.
-        /// Vaults MAY require the ratio of assets to be the same as the ratio
-        /// in the `deposit_assets` field returned by the `VaultInfo` query.
         amount: Option<Uint128>,
-        #[cfg(feature = "cw20")]
-        cw20s_amounts: Option<Vec<Cw20Coin>>,
         /// The address which should receive the withdrawn assets. If not set,
         /// the assets will be sent to the caller.
         recipient: Option<String>,

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -33,9 +33,6 @@ pub enum LockupExecuteMsg {
         /// used instead.
         recipient: Option<String>,
         /// The ID of the expired lockup to withdraw from.
-        /// If None is passed, the vault will attempt to withdraw all expired
-        /// lockup positions. Note that this can fail if there are too many
-        /// lockup positions and the `max_contract_gas` limit is hit.
         lockup_id: u64,
     },
 

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -5,12 +5,19 @@ use cw_utils::{Duration, Expiration};
 #[cfg(feature = "cw20")]
 use cw20::Cw20Coin;
 
+/// Type for the unlocking position created event emitted on call to `Unlock`.
+pub const UNLOCKING_POSITION_CREATED_EVENT_TYPE: &str = "unlocking_position_created";
+/// Key for the lockup id attribute in the "unlocking position created" event that
+/// is emitted on call to `Unlock`.
+pub const UNLOCKING_POSITION_ATTR_KEY: &str = "lockup_id";
+
 #[cw_serde]
 pub enum LockupExecuteMsg {
     /// Unlock is called to initiate unlocking a locked position held by the
     /// vault.
     /// The caller must pass the native vault tokens in the funds field.
-    /// Emits an Unlock event with `amount` attribute containing an u64 lockup_id.
+    /// Emits an event with type `UNLOCK_EVENT_TYPE` with an attribute with key
+    /// `UNLOCKING_POSITION_ATTR_KEY` containing an u64 lockup_id.
     /// Also encodes the u64 lockup ID as binary and returns it in the Response's
     /// data field, so that it can be read by SubMsg replies.
     ///

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Coin, Uint128};
+use cosmwasm_std::{Addr, Uint128};
 use cw_utils::{Duration, Expiration};
 
 #[cfg(feature = "cw20")]

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -53,8 +53,6 @@ pub enum LockupExecuteMsg {
     /// Force withdraw from a position that is already unlocking (Unlock has
     /// already been called).
     ForceWithdrawUnlocking {
-        /// The address of the owner of the position.
-        owner: String,
         /// The ID of the unlocking position from which to force withdraw
         lockup_id: u64,
         /// Optional amounts of each underlying asset to be force withdrawn.

--- a/src/extensions/lockup.rs
+++ b/src/extensions/lockup.rs
@@ -85,7 +85,7 @@ pub enum LockupQueryMsg {
 
     /// Returns `Lockup` info about a specific lockup, by owner and ID.
     #[returns(Lockup)]
-    Lockup { owner: String, lockup_id: u64 },
+    Lockup { lockup_id: u64 },
 
     /// Returns `cw_utils::Duration` duration of the lockup.
     #[returns(Duration)]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -18,7 +18,7 @@ use cosmwasm_std::{Coin, Empty};
 use schemars::JsonSchema;
 
 #[cw_serde]
-pub enum ExecuteMsg<T = ExtensionExecuteMsg, S = Empty> {
+pub enum ExecuteMsg<T = ExtensionExecuteMsg> {
     /// Called to deposit into the vault. Native assets are passed in the funds
     /// parameter.
     Deposit {
@@ -47,9 +47,6 @@ pub enum ExecuteMsg<T = ExtensionExecuteMsg, S = Empty> {
         /// API for both types of vaults, so we require this argument.
         amount: Uint128,
     },
-
-    /// Custom callback functions defined by the vault.
-    Callback(S),
 
     /// Support for custom extensions
     VaultExtension(T),

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -139,6 +139,10 @@ where
     #[returns(AssetsResponse)]
     TotalAssets {},
 
+    /// Returns `Uint128` total amount of vault tokens in circulation.
+    #[returns(Uint128)]
+    TotalVaultTokenSupply {},
+
     /// The amount of shares that the vault would exchange for the amount of
     /// assets provided, in an ideal scenario where all the conditions are met.
     ///

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -75,12 +75,12 @@ where
     /// Returns `VaultStandardInfo` with information on the version of the vault
     /// standard used as well as any enabled extensions.
     #[returns(VaultStandardInfo)]
-    VaultStandardInfo,
+    VaultStandardInfo {},
 
     /// Returns `VaultInfo` representing vault requirements, lockup, & vault
     /// token denom.
     #[returns(VaultInfo)]
-    Info,
+    Info {},
 
     /// Returns `Uint128` amount of vault tokens that will be returned for the
     /// passed in assets.
@@ -140,7 +140,7 @@ where
     /// Useful for display purposes, and does not have to confer the exact
     /// amount of underlying assets.
     #[returns(AssetsResponse)]
-    TotalAssets,
+    TotalAssets {},
 
     /// The amount of shares that the vault would exchange for the amount of
     /// assets provided, in an ideal scenario where all the conditions are met.

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -107,7 +107,7 @@ where
     /// redeemed in exchange for vault tokens. Used by Rover to calculate vault
     /// position values.
     #[returns(AssetsResponse)]
-    PreviewRedeem { shares: Uint128 },
+    PreviewRedeem { amount: Uint128 },
 
     /// Returns `Option<AssetsResponse>` maximum amount of assets that can be
     /// deposited into the Vault for the `recipient`, through a call to Deposit.

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -38,7 +38,8 @@ pub enum ExecuteMsg<T = ExtensionExecuteMsg> {
     /// been passed to ExecuteMsg::Unlock.
     Redeem {
         /// An optional field containing which address should receive the
-        /// withdrawn underlying assets.
+        /// withdrawn underlying assets. If not set, the caller address will be
+        /// used instead.
         recipient: Option<String>,
         /// The amount of vault tokens sent to the contract. In the case that
         /// the vault token is a Cosmos native denom, we of course have this


### PR DESCRIPTION
closes #4 

## Tasks
- [x] Msg's without the brackets do not compile with [ts-codegen](https://github.com/CosmWasm/ts-codegen)
```diff
enum QueryMsg {
 	#[returns(VaultInfo)]
- 	Info
+ 	Info {}
}
```
- [x] I like the idea of custom callback, but do you have any examples of this in use?
- [x] I see `receiver: Option<String>` frequently used. Is this a common need? or a standard contract api field? Does `None` imply that the actions will be executed for the sender?
- [x] For `QueryMsg::PreviewRedeem`, I'd rename the field `shares` to just `amount`.
- [ ] Instead of using the term `Assets`, can we just call it `Coins`?
- [x] We need a query message like: `TotalVaultCoinsIssued {}` in order to price Vault tokens. Here's an example: https://github.com/mars-protocol/rover/blob/d2bd15ff54a59b1cc97bf14ad4a57975bdec98cc/contracts/mars-oracle-adapter/src/contract.rs#L131 of it in use.
- [x] If we renamed `deposit_coins` to `entry_reqs` is that clearer?
- [x] For `LockupQueryMsg::Lockup` and `ForceWithdrawUnlocking`, the field `owner` is required. Why would that be needed? Lockup Ids are unique no?
- [x] Can you update cw-utils to 0.16?
- [x] I find the automated action by leaving lockup_id as `None` to be too smart:
```diff
    WithdrawUnlocked {
         receiver: Option<String>,
-        lockup_id: Option<u64>,
+        lockup_id: u64,
    },
```
- [x] `ForceWithdrawUnlocking` takes `amounts: Option<Vec<Coin>>`. How does the owner know the underlying coins in the lockup in order to do a partial liquidation? No current query supports this. It seems that the Lockup struct needs a `coins: Vec<Coin>` field instead of `amount`.
- [x] Not really clear for me what the use cases for these are
  - PreviewWithdraw
  - PreviewMint
  - MaxDeposit
  - MaxMint
  - MaxWithdraw
  - MaxRedeem
  - ConvertToShares (how is this different than PreviewDeposit?)
  - ConvertToAssets (how is this different than PreviewRedeem?)
- [x] Can you export the event strings? I had something like this:
```rust
pub const UNLOCKING_POSITION_CREATED_EVENT_TYPE: &str = "unlocking_position_created";
pub const UNLOCKING_POSITION_ATTR: &str = "id";
```
- [x] In VaultStandardInfo, can pub extensions: Vec<String>, be more strongly typed? Maybe instead of String an enum?
- [x] What happens when you query LockupDuration on a vault that doesn't have one? It raises an exception?